### PR TITLE
fix: deep-core audit (Mythos §4) — mitosis cooldown seed, child reap,…

### DIFF
--- a/cgo_notorch.go
+++ b/cgo_notorch.go
@@ -70,6 +70,17 @@ func ntTensorGet(t ntTensor, n int) []float32 {
 	return out
 }
 
+// ntTensorSyncCPU refreshes a tensor's host mirror (t->data) from device before
+// a host read. ntx_get does a raw memcpy from t->data, so on the cuda build a
+// GPU-trained tensor must be synced first or the readback into model.Base is
+// stale. No-op on the non-cuda build (nt_tensor_sync_cpu is (void)t there).
+func ntTensorSyncCPU(t ntTensor) {
+	if t == nil {
+		return
+	}
+	C.nt_tensor_sync_cpu(t)
+}
+
 // ── Tape lifecycle ──
 // nt_tape_clear keeps Chuck m/v state (positional, keyed by registration order);
 // nt_tape_destroy wipes it — call destroy+start only after a growth event.

--- a/mitosis_cooldown_test.go
+++ b/mitosis_cooldown_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression guard for the mitosis cooldown seed (deep-core audit bug 1+6).
+// NewSyntropyTracker must seed LastMitosisTime to birth time so the 300s divide
+// cooldown (CASE 6: now-LastMitosisTime>300) also guards the FIRST division.
+// Zero-init made now(epoch-sec)-0 always >300, so seed organisms and every
+// mitosis child could divide instantly. This must never regress.
+func TestMitosisCooldownSeededAtBirth(t *testing.T) {
+	st := NewSyntropyTracker()
+	now := float64(time.Now().UnixMilli()) / 1000.0
+	if st.LastMitosisTime <= 0 {
+		t.Fatalf("LastMitosisTime not seeded: got %v (zero-init bug back)", st.LastMitosisTime)
+	}
+	if d := now - st.LastMitosisTime; d < 0 || d > 5 {
+		t.Fatalf("LastMitosisTime not ~= now: now-LMT=%v s (want 0..5)", d)
+	}
+	// The divide gate (now-LastMitosisTime > 300) MUST be false at birth.
+	if now-st.LastMitosisTime > 300 {
+		t.Fatalf("divide cooldown not enforced at birth: now-LMT=%v > 300", now-st.LastMitosisTime)
+	}
+}

--- a/molequla.go
+++ b/molequla.go
@@ -5037,6 +5037,11 @@ type SyntropyTracker struct {
 func NewSyntropyTracker() *SyntropyTracker {
 	return &SyntropyTracker{
 		LastAction: "none",
+		// Seed birth time so the 300s divide cooldown (CASE 6, now-LastMitosisTime>300)
+		// also guards the FIRST division. Zero-init made now(epoch-sec)-0 always >300,
+		// so seed organisms and every mitosis child could divide instantly. Applies
+		// uniformly: the seed tracker here and each child's fresh tracker (backgroundTrainer).
+		LastMitosisTime: float64(time.Now().UnixMilli()) / 1000.0,
 	}
 }
 
@@ -5603,6 +5608,10 @@ func performMitosis(model *GPT, tok *EvolvingTokenizer, db *sql.DB, swarm *Swarm
 	if err := cmd.Start(); err != nil {
 		return "", err
 	}
+	// Reap the child on its eventual exit so it cannot become a zombie of this
+	// long-lived parent. cmd.Start without a matching Wait leaks a zombie per
+	// division — across a cascade that accumulates and feeds process-table pressure.
+	go func() { _ = cmd.Wait() }()
 
 	syntracker.LastMitosisTime = float64(time.Now().UnixMilli()) / 1000.0
 	fmt.Printf("[ecology] Child %s spawned (pid=%d)\n", childID, cmd.Process.Pid)

--- a/notorch_trainer.go
+++ b/notorch_trainer.go
@@ -361,7 +361,10 @@ func ntTrainCore(model *GPT, tok *EvolvingTokenizer, docs []string, steps, seqLe
 	elapsedMs := float64(time.Since(t0).Microseconds()) / 1000.0
 
 	// Mirror trained weights back into the canonical model.Base store.
+	// Sync each tensor's host mirror from device first — ntx_get is a raw memcpy
+	// from t->data, which is stale after GPU training on the cuda build (no-op on CPU).
 	for i, p := range params {
+		ntTensorSyncCPU(tensors[i])
 		ntUnflattenMatrix(p.mp, ntTensorGet(tensors[i], p.mp.Nout*p.mp.Nin))
 	}
 	// Inc2: split the trained combined Wr back into the wr_a / wr_b Base matrices.
@@ -375,6 +378,7 @@ func ntTrainCore(model *GPT, tok *EvolvingTokenizer, docs []string, steps, seqLe
 			if a == nil || b == nil {
 				continue
 			}
+			ntTensorSyncCPU(wrTensors[l])
 			ntUnpackWr(model, l, ntTensorGet(wrTensors[l], a.Nout*a.Nin+b.Nout*b.Nin))
 		}
 	}


### PR DESCRIPTION
… GPU readback sync

Closes 4 adversarially-confirmed findings from the read-only deep-core audit that executes the §4 map Mythos (Fable 5) named but did not run.

- BUG 1+6 (high): seed LastMitosisTime at NewSyntropyTracker birth so the 300s divide cooldown guards the FIRST division. Zero-init made now(epoch)-0 always
  > 300, so the seed organism AND every mitosis child (fresh tracker) could
  divide instantly. + regression test mitosis_cooldown_test.go.
- BUG 7 (low): reap mitosis children (go cmd.Wait) — cmd.Start without a matching Wait leaks a zombie per division across a cascade.
- BUG 4 (high): sync each trained tensor's host mirror before readback into model.Base. ntx_get is a raw memcpy from t->data, stale after GPU training on the cuda build; no-op on CPU (nt_tensor_sync_cpu is (void)t there).

Verified: go build ./... exit 0; go vet ./... exit 0; go test ./... green, 135 tests pass (incl. the new regression test). GPU sync: CPU no-op proven (notorch.c:111-115); cuda device->host path UNVERIFIED on polygon (no GPU) — confirm on next GPU run.


Coordinated with Oleg Ataeff (maintainer)
Verified by 135 tests — all green (go build + go test ./..., reproducible).