### PR TITLE
fix(mitosis): close four lifecycle findings from the Codex audit + notorch darwin/arm64 link

### DIFF
--- a/cgo_notorch.go
+++ b/cgo_notorch.go
@@ -2,6 +2,7 @@ package main
 
 /*
 #cgo CFLAGS: -I/usr/local/include/ariannamethod -O2
+#cgo darwin CFLAGS: -I/opt/homebrew/include
 #cgo linux CFLAGS: -DUSE_BLAS -I/usr/include/x86_64-linux-gnu/openblas-pthread/
 #include <notorch.h>
 #include <string.h>

--- a/cgo_notorch_cpu.go
+++ b/cgo_notorch_cpu.go
@@ -9,5 +9,6 @@ package main
 
 /*
 #cgo linux LDFLAGS: -L/usr/local/lib -lnotorch -L/usr/lib/x86_64-linux-gnu/openblas-pthread/ -lopenblas -lm
+#cgo darwin LDFLAGS: -L/opt/homebrew/lib -lnotorch
 */
 import "C"

--- a/governor_test.go
+++ b/governor_test.go
@@ -112,3 +112,38 @@ func TestCheckpointDebounce(t *testing.T) {
 	}
 }
 
+// (M-GOV-001) A reserved child slot counts toward the population cap immediately,
+// so a sibling cannot overshoot the cap in the window before the child boots and
+// self-registers. Before the fix the cap only saw self-registered organisms, so a
+// spawned-but-not-yet-registered child let the next AcquireMitosisSlot admit an
+// over-cap divide.
+func TestReservedChildCountsTowardCap(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Skipf("sqlite unavailable: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE organisms(id TEXT PRIMARY KEY, pid INTEGER, stage INTEGER, n_params INTEGER, syntropy REAL, entropy REAL, last_heartbeat REAL, parent_id TEXT, status TEXT, element TEXT)`); err != nil {
+		t.Skipf("sqlite exec: %v", err)
+	}
+	db.Exec(`CREATE TABLE mitosis_lock(organism_id TEXT PRIMARY KEY, acquired_at REAL)`)
+	now := float64(time.Now().UnixMilli()) / 1000.0
+	for _, id := range []string{"a", "b", "c"} { // 3 live
+		db.Exec(`INSERT INTO organisms(id,status,last_heartbeat) VALUES(?,?,?)`, id, "alive", now)
+	}
+	parent := &SwarmRegistry{OrganismID: "a", MeshDB: db}
+
+	if !parent.AcquireMitosisSlot(4) {
+		t.Fatal("3 live < cap 4 must admit the divide")
+	}
+	// The parent reserves the child's slot immediately on a successful spawn.
+	parent.ReserveChildSlot("a_child", 12345, "earth")
+	parent.ReleaseMitosisLock()
+
+	// Now 4 live (3 originals + the reserved child) at cap 4: the next divide MUST
+	// be refused even though the child has not yet self-registered on its own.
+	if parent.AcquireMitosisSlot(4) {
+		t.Fatal("reserved child must count toward the cap: 4 live at cap 4 must refuse")
+	}
+}
+

--- a/molequla.go
+++ b/molequla.go
@@ -4471,10 +4471,16 @@ func GenerateResonant(model *GPT, tok *EvolvingTokenizer, field *CooccurField, p
 	if !useModel || model == nil {
 		return CorpusGenerate(tok, field, prompt, CFG.CorpusGenMaxTokens)
 	}
-
 	model.mu.Lock()
 	defer model.mu.Unlock()
+	return generateResonantLocked(model, tok, field, prompt, docs, useModel)
+}
 
+// generateResonantLocked is the body of GenerateResonant. The caller MUST already
+// hold model.mu. Split out so the SPA reseed path (which runs while the lock is
+// held) can recurse without re-locking the non-reentrant model.mu — the recursive
+// re-lock was a self-deadlock (M-LCK-001).
+func generateResonantLocked(model *GPT, tok *EvolvingTokenizer, field *CooccurField, prompt string, docs []string, useModel bool) string {
 	gradEnabled.Store(false)
 	defer func() { gradEnabled.Store(true) }()
 
@@ -5007,7 +5013,7 @@ func GenerateResonant(model *GPT, tok *EvolvingTokenizer, field *CooccurField, p
 							// Recursive call — disable SPA inside.
 							savedSPA := CFG.SPACoherenceGate
 							CFG.SPACoherenceGate = false
-							regenerated := GenerateResonant(model, tok, field, seedPrompt, docs, true)
+							regenerated := generateResonantLocked(model, tok, field, seedPrompt, docs, true)
 							CFG.SPACoherenceGate = savedSPA
 							regenerated = strings.TrimSpace(regenerated)
 							newSentence := strings.TrimSpace(firstSentence(regenerated))
@@ -5562,6 +5568,22 @@ func (sr *SwarmRegistry) registerInMesh() error {
 	return err
 }
 
+// ReserveChildSlot inserts a freshly-spawned child into the mesh as 'alive' with a
+// current heartbeat, so AcquireMitosisSlot's population cap counts it immediately
+// (M-GOV-001). Without this the child is invisible to the cap until it boots and
+// self-registers, letting a sibling overshoot the cap in that window. The child
+// overwrites this row on its own registerInMesh (INSERT OR REPLACE, same id). A
+// child that never boots ages out of the cap once its heartbeat goes stale.
+func (sr *SwarmRegistry) ReserveChildSlot(childID string, pid int, element string) {
+	if sr.MeshDB == nil {
+		return
+	}
+	sr.MeshDB.Exec(
+		"INSERT OR REPLACE INTO organisms(id,pid,stage,n_params,syntropy,entropy,last_heartbeat,parent_id,status,element) "+
+			"VALUES(?,?,0,0,0.0,0.0,?,?,'alive',?)",
+		childID, pid, float64(time.Now().UnixMilli())/1000.0, sr.OrganismID, element)
+}
+
 // Heartbeat performs periodic state update in mesh.db.
 func (sr *SwarmRegistry) Heartbeat(stage, nParams int, syntropy, entropy float64) {
 	if sr.MeshDB == nil {
@@ -5668,11 +5690,46 @@ func (sr *SwarmRegistry) ReleaseTrainingLock() {
 // performMitosis divides the organism. Parent continues. The child inherits the
 // parent's growth stage via the checkpoint dimensions (not infant).
 func performMitosis(model *GPT, tok *EvolvingTokenizer, db *sql.DB, swarm *SwarmRegistry, syntracker *SyntropyTracker) (string, error) {
-	childID := fmt.Sprintf("org_%d_%d", time.Now().Unix(), rand.Intn(9000)+1000)
-	childDir := filepath.Join(os.Getenv("HOME"), ".molequla", childID)
-	if err := os.MkdirAll(childDir, 0755); err != nil {
+	// M-SPAWN-002: allocate a unique child dir EXCLUSIVELY. os.MkdirAll silently
+	// reuses an existing dir, so a childID collision (same second, or the governor
+	// disabled) let two children share a dir and organism id. UnixNano+pid+rand plus
+	// an exclusive os.Mkdir (which fails if the dir exists) makes a collision both
+	// astronomically unlikely and detected.
+	baseDir := filepath.Join(os.Getenv("HOME"), ".molequla")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return "", err
 	}
+	var childID, childDir string
+	for attempt := 0; attempt < 8; attempt++ {
+		childID = fmt.Sprintf("org_%d_%d_%d", time.Now().UnixNano(), os.Getpid(), rand.Intn(1000000))
+		childDir = filepath.Join(baseDir, childID)
+		err := os.Mkdir(childDir, 0755)
+		if err == nil {
+			break
+		}
+		if !os.IsExist(err) {
+			return "", err
+		}
+		childID = ""
+	}
+	if childID == "" {
+		return "", fmt.Errorf("mitosis: could not allocate a unique child dir")
+	}
+
+	// M-SPAWN-001: a failed spawn must NOT leave the parent "relieved" and cooled
+	// down with no child. Snapshot the overload state and restore it unless the
+	// spawn commits (committed=true just before the successful return below).
+	savedLMT := syntracker.LastMitosisTime
+	savedBH := append([]BurstRecord(nil), syntracker.BurstHistory...)
+	savedEH := append([]float64(nil), syntracker.EntropyHistory...)
+	committed := false
+	defer func() {
+		if !committed {
+			syntracker.LastMitosisTime = savedLMT
+			syntracker.BurstHistory = savedBH
+			syntracker.EntropyHistory = savedEH
+		}
+	}()
 
 	// (audit C4 + c) Relieve the parent's overload and stamp the cooldown BEFORE
 	// capturing the inherited history below — so the child does NOT inherit a
@@ -5747,6 +5804,15 @@ func performMitosis(model *GPT, tok *EvolvingTokenizer, db *sql.DB, swarm *Swarm
 	// Reap the child on its eventual exit (no zombie of this long-lived parent)
 	// and close its log handle.
 	go func() { _ = cmd.Wait(); if childLog != nil { childLog.Close() } }()
+
+	// M-GOV-001: reserve the child's slot in the mesh NOW so the population cap
+	// counts it immediately. Otherwise a sibling's AcquireMitosisSlot, run in the
+	// window before the child self-registers, sees COUNT < cap and admits an
+	// over-cap spawn. The child overwrites this row (INSERT OR REPLACE) on boot.
+	swarm.ReserveChildSlot(childID, cmd.Process.Pid, swarm.Element)
+
+	// M-SPAWN-001: the spawn is committed — keep the relieved/cooled parent state.
+	committed = true
 
 	fmt.Printf("[ecology] Child %s spawned (pid=%d) — log %s/train.log\n", childID, cmd.Process.Pid, childDir)
 	return childID, nil


### PR DESCRIPTION
Closes four organism-lifecycle findings from the Codex audit of the mitosis/governor path, plus a darwin/arm64 build fix. Branch is 2 commits ahead of `main`, 0 behind. New coverage in `governor_test.go`.

## Lifecycle findings (`molequla.go`)

- **M-LCK-001 — recursive self-deadlock.** The SPA reseed path re-entered `GenerateResonant` while already holding the non-reentrant `model.mu`, deadlocking. Split the body into `generateResonantLocked` (caller must hold the lock); the reseed recursion now calls the locked body directly.
- **M-GOV-001 — over-cap divide window.** The population cap only counted self-registered organisms, so a spawned-but-not-yet-booted child was invisible to `AcquireMitosisSlot`, letting a sibling overshoot the cap. New `ReserveChildSlot` inserts the child as `alive` with a live heartbeat immediately on spawn; the child overwrites its own row on `registerInMesh` (INSERT OR REPLACE), and a child that never boots ages out via stale heartbeat.
- **M-SPAWN-002 — child dir/id collision.** `os.MkdirAll` silently reused an existing dir, so a childID collision (same second, or governor disabled) let two children share a dir and organism id. Now UnixNano+pid+rand with an exclusive `os.Mkdir` (fails if the dir exists) — collision both astronomically unlikely and detected, retried up to 8×.
- **M-SPAWN-001 — failed-spawn relief leak.** A failed spawn left the parent “relieved” and cooled down with no child. Snapshot `LastMitosisTime` / `BurstHistory` / `EntropyHistory` and restore them via `defer` unless the spawn commits.

## Build

- **notorch darwin/arm64 link** — `cgo_notorch.go`, `cgo_notorch_cpu.go`.

## Tests

- `TestReservedChildCountsTowardCap` — a reserved child counts toward the cap immediately: 3 live under cap 4 admits a divide; after `ReserveChildSlot` the 4th live at cap 4 is refused before the child self-registers.